### PR TITLE
Simple concatenate functionality

### DIFF
--- a/src/pypcd4/pypcd4.py
+++ b/src/pypcd4/pypcd4.py
@@ -668,6 +668,26 @@ class PointCloud:
         _stack = tuple(self.pc_data[field] for field in fields)
 
         return np.vstack(_stack).T
+    
+    def concatenate(self, other: PointCloud) -> PointCloud:
+        """
+        Concatenates two point clouds together
+        """
+        return self.__add__(other)
+
+    def __add__(self, other: PointCloud) -> PointCloud:
+        """
+        Concatenates two point clouds together
+        """
+
+        if self.metadata.fields != other.metadata.fields:
+            raise ValueError("Can't concatenate point clouds with different fields")
+        if self.metadata.type != other.metadata.type:
+            raise ValueError("Can't concatenate point clouds with different metadata")
+        concatenated_pc = PointCloud(self.metadata, np.hstack([self.pc_data, other.pc_data]))
+        concatenated_pc.metadata.points += other.metadata.points
+        concatenated_pc.metadata.width += other.metadata.width
+        return concatenated_pc
 
     def _save_as_ascii(self, fp: BinaryIO) -> None:
         """Saves point cloud to a file as a ascii
@@ -702,7 +722,7 @@ class PointCloud:
         Args:
             fp (BinaryIO): io buffer.
         """
-
+ 
         uncompressed = b"".join(
             np.ascontiguousarray(self.pc_data[field]).tobytes()
             for field in self.pc_data.dtype.names

--- a/tests/test/test_pypcd4.py
+++ b/tests/test/test_pypcd4.py
@@ -734,3 +734,33 @@ def test_save_to_bytes_io():
     assert pc2.types == pc.types
     assert pc2.points == pc.points
     assert pc2.metadata.data == pc.metadata.data
+
+def test_pointcloud_concatenation():
+    in_points = np.random.randint(0, 1000, (100, 3))
+    fields = ("x", "y", "z")
+    types = (np.float32, np.int8, np.uint64)
+    pc = PointCloud.from_points(in_points, fields, types)
+
+    # Can concatenate PointCloud
+    in_points = np.random.randint(0, 1000, (100, 3))
+    pc2 = PointCloud.from_points(in_points, fields, types)
+    pc3 = pc + pc2
+    assert pc3.points == 200
+    assert len(pc3.pc_data) == 200
+    assert len(pc3.pc_data.dtype) == 3
+    assert pc3.fields == pc.fields
+    assert pc3.types == pc.types
+    assert pc3.metadata.data == pc.metadata.data
+    assert np.allclose(pc3.numpy(), np.concatenate((pc.numpy(), pc2.numpy()), axis=0))
+
+    # Cannot concatenate fields are different
+    pc4 = PointCloud.from_points(in_points, ("x", "y", "zz"), types)
+    with pytest.raises(ValueError):
+        pc + pc4
+
+    # Cannot concatenate because types are different
+    pc5 = PointCloud.from_points(in_points, fields, (np.float32, np.int8, np.float32))
+    with pytest.raises(ValueError):
+        pc + pc5
+
+


### PR DESCRIPTION
Simple functionality concatenate two PointCloud objects with addition operator or concatenate function. Creates a temporary concatenate_pc (is it better to directly overwrite self?).

Raises ValueError when the fields don't match exactly and when the types don't match.

May be better not to __add__ and simply use .concatenate(), up to you.