### PR TITLE
Add GitHub Actions workflow for deploying to TestPyPI

### DIFF
--- a/.github/workflows/deploy-testpypi.yaml
+++ b/.github/workflows/deploy-testpypi.yaml
@@ -1,0 +1,38 @@
+name: Deploy to TestPyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Rye
+        uses: eifinger/setup-rye@v2
+        with:
+          enable-cache: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync with Rye
+        run: rye sync
+
+      - name: Build distribution packages
+        run: rye build --clean
+
+      - name: Publish to TestPyPI
+        run: >
+          rye publish
+            --yes
+            --verbose
+            --repository testpypi
+            --repository-url https://test.pypi.org/legacy/
+            --token ${{ secrets.TEST_PYPI_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow that automates the deployment of our package to TestPyPI.

- Adds a new GitHub Actions workflow for deploying to TestPyPI
- Configures the workflow to use Rye for building and publishing packages