### PR TITLE
Add PyPI deployment workflow for Python packages

### DIFF
--- a/.github/workflows/deploy-pypi.yaml
+++ b/.github/workflows/deploy-pypi.yaml
@@ -1,0 +1,33 @@
+name: Deploy to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Rye
+        uses: eifinger/setup-rye@v2
+        with:
+          enable-cache: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync with Rye
+        run: rye sync
+
+      - name: Build distribution packages
+        run: rye build --clean
+
+      - name: Publish to PyPI
+        run: rye publish --yes --verbose --token ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This pull request adds a new deployment workflow to deploy Python packages to PyPI.

The changes include:
- Added a new workflow file `deploy-pypi.yaml` that uses actions/checkout, setup-python, and setup-rye to set up the environment.
- Configured the workflow to run on release types of [published].
- Implemented steps to sync with Rye, build distribution packages, and publish to PyPI using the provided secrets.