### PR TITLE
Fix to prevent infinite loop when loading invalid files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,3 +315,11 @@ def xyzrgb_binary_compressed_path():
 @pytest.fixture
 def xyzintensity_binary_compressed_organized_path():
     return f"{Path(__file__).resolve().parent}/pcd/binary_compressed_organized.pcd"
+
+@pytest.fixture
+def ascii_empty_path():
+    return f"{Path(__file__).resolve().parent}/pcd/ascii_empty.pcd"
+
+@pytest.fixture
+def ascii_invalid_header_path():
+    return f"{Path(__file__).resolve().parent}/pcd/ascii_invalid_header.pcd"

--- a/tests/pcd/ascii_invalid_header.pcd
+++ b/tests/pcd/ascii_invalid_header.pcd
@@ -1,0 +1,3 @@
+# .PCD v.7 - Point Cloud Data file format
+VERSION .7
+FIEL

--- a/tests/test/test_pypcd4.py
+++ b/tests/test/test_pypcd4.py
@@ -276,6 +276,16 @@ def test_load_binary_compressed_organized_pcd(xyzintensity_binary_compressed_org
     assert len(pc.pc_data) == pc.metadata.points
 
 
+def test_load_ascii_empty_pcd(ascii_empty_path):
+    with pytest.raises(ValidationError):
+        PointCloud.from_path(ascii_empty_path)
+
+
+def test_load_ascii_invalid_header_pcd(ascii_invalid_header_path):
+    with pytest.raises(ValidationError):
+        PointCloud.from_path(ascii_invalid_header_path)
+
+
 def test_from_points():
     array = np.array([[1, 2, 3], [4, 5, 6]])
     fields = ("x", "y", "z")


### PR DESCRIPTION
This PR fixes an issue where the library would enter an infinite loop when trying to load a PCD file with an invalid header. This fix involves updating the `from_fileobj` method to correctly 
handle invalid headers and prevent infinite loops.

The changes include:
- Updated the `from_fileobj` method to parse PCD files with invalid headers correctly
- Added tests for loading PCD files with invalid headers to prevent regression issues

This PR closes #20 