### PR TITLE
Feature/rosbags support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,26 @@
 
 ## Table of Contents
 
-* [Description](#description)
-* [Installation](#installation)
-* [Usage](#usage)
-  * [Importing pypcd4](#getting-started)
-  * [Loading PCD File](#working-with-pcd-files)
-  * [Converting to NumPy Array](#converting-between-pointcloud-and-numpy-array)
-  * [Converting to ROS Message](#working-with-ros-pointcloud2-messages)
-  * [Concatenating PointClouds](#concatenating-two-pointclouds)
-  * [Filtering PointClouds](#filtering-a-pointcloud)
-  * [Saving Your Work](#saving-your-work)
-* [Contributing](#contributing)
-* [License](#license)
+- [pypcd4](#pypcd4)
+  - [Table of Contents](#table-of-contents)
+  - [Description](#description)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Getting Started](#getting-started)
+    - [Working with .pcd Files](#working-with-pcd-files)
+    - [Converting Between PointCloud and NumPy Array](#converting-between-pointcloud-and-numpy-array)
+      - [Creating Custom Conversion Methods](#creating-custom-conversion-methods)
+    - [Working with ROS PointCloud2 Messages](#working-with-ros-pointcloud2-messages)
+    - [Concatenating Two PointClouds](#concatenating-two-pointclouds)
+    - [Filtering a PointCloud](#filtering-a-pointcloud)
+      - [Using a Slice](#using-a-slice)
+      - [Using a Boolean Mask](#using-a-boolean-mask)
+      - [Using Field Names](#using-field-names)
+    - [Saving Your Work](#saving-your-work)
+  - [Contributing](#contributing)
+    - [Using Rye (Recommended)](#using-rye-recommended)
+    - [Using pip](#using-pip)
+  - [License](#license)
 
 ## Description
 
@@ -105,7 +113,7 @@ pc = PointCloud.from_points(array, fields, types)
 
 ### Working with ROS PointCloud2 Messages
 
-You can convert a ROS PointCloud2 Message to a PointCloud and vice versa:
+You can convert a ROS PointCloud2 Message to a PointCloud and vice versa. This requires ROS installed and sourced, or [rosbags](https://ternaris.gitlab.io/rosbags/index.html) to be installed. To publish the converted message, ROS is required:
 
 ```python
 def callback(in_msg: sensor_msgs.msg.PointCloud2):
@@ -118,6 +126,7 @@ def callback(in_msg: sensor_msgs.msg.PointCloud2):
     # Convert PointCloud to ROS PointCloud2 Message with the input message header
     out_msg = pc.to_msg(in_msg.header)
 
+    # Publish using ROS (or e.g. write to a rosbag)
     publisher.publish(out_msg)
 ```
 

--- a/tests/test/test_pypcd4.py
+++ b/tests/test/test_pypcd4.py
@@ -934,3 +934,19 @@ def test_pointcloud_getitem_with_field_names():
     # Cannot filter by fields names since the field name "a" is invalid
     with pytest.raises(ValueError):
         pc[("x", "y", "a")]
+        
+def test_pointcloud_tomsg():
+    in_points = np.random.randint(0, 1000, (100, 3))
+    fields = ("x", "y", "z")
+    types = (np.float32, np.int8, np.uint32)
+    pc = PointCloud.from_points(in_points, fields, types)
+
+    try:
+        msg = pc.to_msg()
+    except ImportError:
+        pytest.skip("ROS or rosbags is not installed")
+    pc2 = PointCloud.from_msg(msg)
+    assert np.allclose(pc2.numpy(), pc.numpy())
+    assert pc2.fields == pc.fields
+    assert pc2.types == pc.types
+    assert pc2.points == pc.points


### PR DESCRIPTION
Add the choice between actual ROS/ROS2 or [rosbags](https://ternaris.gitlab.io/rosbags/index.html) API for getting ROS message types.

Useful for ROS agnostic systems reading/writing to rosbag files.

Added optional test because no hard dependency on either ROS or rosbags.