### PR TITLE
Feature/from list : merge a list of PointCloud objects into one PointCloud object

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     - [Converting Between PointCloud and NumPy Array](#converting-between-pointcloud-and-numpy-array)
       - [Creating Custom Conversion Methods](#creating-custom-conversion-methods)
     - [Working with ROS PointCloud2 Messages](#working-with-ros-pointcloud2-messages)
-    - [Concatenating Two PointClouds](#concatenating-two-pointclouds)
+    - [Concatenating PointClouds](#concatenating-pointclouds)
     - [Filtering a PointCloud](#filtering-a-pointcloud)
       - [Using a Slice](#using-a-slice)
       - [Using a Boolean Mask](#using-a-boolean-mask)
@@ -130,10 +130,10 @@ def callback(in_msg: sensor_msgs.msg.PointCloud2):
     publisher.publish(out_msg)
 ```
 
-### Concatenating Two PointClouds
+### Concatenating PointClouds
 
-The `pypcd4` supports concatenating two `PointCloud` objects together using the `+` operator.
-This can be very useful when you want to merge two point clouds into one.
+The `pypcd4` supports concatenating `PointCloud` objects together using the `+` operator.
+This can be useful when you want to merge two point clouds into one.
 
 Here's how you can use it:
 
@@ -145,7 +145,17 @@ pc2: PointCloud = PointCloud.from_path("xyzi2.pcd")
 pc3: PointCloud = pc1 + pc2
 ```
 
-Please note that the two PointCloud objects must have the same fields and types. If they don’t, a `ValueError` will be raised.
+Concatenating many PointClouds in sequence can become slow, especially for large point counts. Using `PointCloud.from_list()` will be faster for those use cases:
+
+```python
+pc_list = []
+for i in range(10):
+    pc_list.append(PointCloud.from_path(f"xyzi{i}.pcd"))
+
+pc: PointCloud = PointCloud.from_list(pc_list)
+```
+
+Please note that to concatenate PointCloud objects, they must have the exact same fields and types. If they don’t, a `ValueError` will be raised.
 
 ### Filtering a PointCloud
 

--- a/src/pypcd4/pypcd4.py
+++ b/src/pypcd4/pypcd4.py
@@ -562,6 +562,12 @@ class PointCloud:
         return PointCloud.from_points(points, fields, types)
 
     @staticmethod
+    def from_list(pcs: List[PointCloud]) -> PointCloud:
+        if not all(pc.fields == pcs[0].fields and pc.types == pcs[0].types for pc in pcs):
+            raise ValueError("from_list: All PointClouds must have the same fields and types")
+        return PointCloud.from_points(np.concatenate([pc.numpy() for pc in pcs]), pcs[0].fields, pcs[0].types)
+
+    @staticmethod
     def from_msg(msg: sensor_msgs__msg__PointCloud2) -> PointCloud:
         """Create a PointCloud from a ROS/ROS 2 sensor_msgs.msg.PointCloud2 message
 
@@ -960,12 +966,12 @@ class PointCloud:
 
         if self.fields != other.fields:
             raise ValueError(
-                "Can't concatenate point clouds with different fields. "
+                "add: Can't concatenate point clouds with different fields. "
                 f"({self.fields} vs. {other.fields})"
             )
         if self.types != other.types:
             raise ValueError(
-                "Can't concatenate point clouds with different types. "
+                "add: Can't concatenate point clouds with different types. "
                 f"({self.types} vs. {other.types})"
             )
 

--- a/src/pypcd4/pypcd4.py
+++ b/src/pypcd4/pypcd4.py
@@ -565,7 +565,9 @@ class PointCloud:
     def from_list(pcs: List[PointCloud]) -> PointCloud:
         if not all(pc.fields == pcs[0].fields and pc.types == pcs[0].types for pc in pcs):
             raise ValueError("from_list: All PointClouds must have the same fields and types")
-        return PointCloud.from_points(np.concatenate([pc.numpy() for pc in pcs]), pcs[0].fields, pcs[0].types)
+        return PointCloud.from_points(
+            np.concatenate([pc.numpy() for pc in pcs]), pcs[0].fields, pcs[0].types
+        )
 
     @staticmethod
     def from_msg(msg: sensor_msgs__msg__PointCloud2) -> PointCloud:

--- a/tests/test/test_pypcd4.py
+++ b/tests/test/test_pypcd4.py
@@ -950,3 +950,15 @@ def test_pointcloud_tomsg():
     assert pc2.fields == pc.fields
     assert pc2.types == pc.types
     assert pc2.points == pc.points
+
+def test_list_pointcloud():
+    in_points = np.random.randint(0, 1000, (100, 3))
+    fields = ("x", "y", "z")
+    types = (np.float32, np.float32, np.float32)
+    pc = PointCloud.from_points(in_points, fields, types)
+    num_pcs = 3
+    pc_list = [pc] * num_pcs
+    concatenated_pc = PointCloud.from_list(pc_list)
+    assert concatenated_pc.points == pc.points * num_pcs
+    assert concatenated_pc.fields == pc.fields
+    assert concatenated_pc.types == pc.types


### PR DESCRIPTION
In this PR, I add `from_list` static method to the PointCloud class which lets you construct a large list of PointCloud objects before merging them all together in one step using a single np.concatenate. The same rules apply as add operator, where all PointCloud objects must have the same structure.

The reason for introducing this method as alternative to additive operator is as follow:

Add `+` operator is fine for concatenating two pointclouds with not too many points.
<img src="https://github.com/user-attachments/assets/bdc06097-c087-4520-a2b9-44934bf6439e" alt="two_pcs" width="600"/>

However, this scales very poorly for concatenating multiple (e.g. 10) pointclouds
<img src="https://github.com/user-attachments/assets/8e351ee4-56ef-49bc-8e2b-fd3c547b8e7a" alt="ten_pcs" width="600"/>

The gap gets exponentially larger for large pointclouds (notice the log-log scale)
<img src="https://github.com/user-attachments/assets/bc036b1e-8d70-49a8-a61e-45997eb2cab8" alt="ten_big_pcs" width="600"/>

For use cases with large number of points or many objects, additive operator is too slow. There may be a faster alternative that doesn't require .numpy(), directly working on the `pc_data` and manually defining the header, but I'm not sure. 

Simple test code: 
```
import pypcd4
import numpy as np
from time import perf_counter

num_iterations = 100
test_idxs = [1e5,1e6,1e7,1e8]
# test_idxs = [1e5, 2e5, 3e5, 4e5, 5e5, 6e5, 7e5, 8e5, 9e5]
add_times = []
from_list_times = []
for i in test_idxs:
  print(f"Testing {i}")
  pc = np.random.randint(0, 100000, (int(i), 3))
  fields = ("x", "y", "z")
  types = (np.float32, np.float32, np.float32)
  pcd = pypcd4.PointCloud.from_points(pc, fields, types)
  
  start_time = perf_counter()
  for _ in range(num_iterations):
    concatenated_pc = pcd + pcd + pcd + pcd + pcd + pcd + pcd + pcd + pcd + pcd
  add_times.append((perf_counter() - start_time)/num_iterations)
  
  start_time = perf_counter()
  for _ in range(num_iterations):
    from_list_pc = pypcd4.PointCloud.from_list([pcd, pcd, pcd, pcd, pcd, pcd, pcd, pcd, pcd, pcd])
  from_list_times.append((perf_counter() - start_time)/num_iterations)
```