### PR TITLE
pin hatchling to 1.26.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ urls.Tracker = "https://github.com/MapIV/pypcd4/issues"
 dev = ["ruff", "mypy", "setuptools-scm"]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+# pinned hatchling version because https://github.com/astral-sh/rye/issues/1446
+requires = ["hatchling==1.26.3", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.rye]


### PR DESCRIPTION
This PR pins the `hatchling` version to 1.26.3 to prevent [this issue](https://github.com/astral-sh/rye/issues/1446#issuecomment-2546425240) during publishing to PyPI.