### PR TITLE
Fix/ros1 ros2 rosbags support

### DIFF
--- a/tests/test/test_pypcd4.py
+++ b/tests/test/test_pypcd4.py
@@ -962,3 +962,8 @@ def test_list_pointcloud():
     assert concatenated_pc.points == pc.points * num_pcs
     assert concatenated_pc.fields == pc.fields
     assert concatenated_pc.types == pc.types
+    
+if __name__ == "__main__":
+    print("Testing PointCloud msg functionality...")
+    test_pointcloud_tomsg()
+    print("Msg test passed!")


### PR DESCRIPTION
* Fixes the prioritization of ROS1 / ROS2 over Rosbags API if both are installed. Now, ROS or ROS2 is prioritized for publishing reasons, but having Rosbags API side-by-side doesn't cause issues anymore.
* Pytest and ROS2 don't play well together, so I added a manual test. Not ideal, having ROS2 as a test dependency is very inconvenient.
* Fixed the encoding of PointCloud2 data to ROS msg which caused issues when publishing or saving to Rosbag via ROS1/ROS2 rosbags API.

As a dev note related to this PR: We'd like to support native ROS messages, but this has created a mess of imports we tried to accommodate here. If too many unforeseen circumstances occur which impact users without using ROS (which we think is most users) we are considering removing support from the scope of this project.

Close #35