### PR TITLE
Fix save and load logic for binary_compressed encoding

### DIFF
--- a/src/pypcd4/pypcd4.py
+++ b/src/pypcd4/pypcd4.py
@@ -924,7 +924,9 @@ class PointCloud:
         )
 
         if (compressed := lzf.compress(uncompressed)) is None:
-            compressed = uncompressed
+            fp.seek(0)
+            self.save(fp, encoding=Encoding.BINARY)
+            return
 
         fp.write(struct.pack("II", len(compressed), len(uncompressed)))
         fp.write(compressed)
@@ -941,7 +943,7 @@ class PointCloud:
 
         is_open = False
         if isinstance(fp, Path):
-            fp = fp.open("wb")
+            fp = fp.open(mode="wb")
             is_open = True
         elif isinstance(fp, str):
             fp = open(fp, mode="wb")


### PR DESCRIPTION
This PR corrects the save and load logic for binary_compressed encoding, thereby addressing issue #37.
Close #37 