### PR TITLE
build: bump python-neo-lzf to 0.3.5 and remove Linux ARM fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,7 @@ authors = [{ name = "urasakikeisuke", email = "keisuke.urasaki@map4.jp" }]
 dependencies = [
     "numpy>=1.21.0",
     "pydantic >=1.10.8, <3.0.0",
-
-    # NOTE: `python-neo-lzf` currently lacks pre-built wheels for Linux aarch64.
-    # To avoid compilation errors on Linux ARM environments, we use `python-lzf` as a fallback.
-    # macOS ARM64 (Apple Silicon) is supported by `python-neo-lzf` (Universal2), so it is not affected.
-
-    # 1. Fallback: Use `python-lzf` ONLY on Linux ARM64.
-    "python-lzf; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64')",
-
-    # 2. Standard: Use `python-neo-lzf` on all other platforms (macOS, Windows, x86_64 Linux, etc.).
-    "python-neo-lzf>=0.3.0; sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64')",
+    "python-neo-lzf>=0.3.5",
 ]
 readme = "README.md"
 requires-python = ">= 3.8.2"


### PR DESCRIPTION
## Summary
This PR removes the temporary workaround introduced in v1.4.1/v1.4.2.
Since `python-neo-lzf` v0.3.5 now [provides wheels for Linux aarch64](https://pypi.org/project/python-neo-lzf/0.3.5/#files), we no longer need to fall back to `python-lzf`.

## Changes
- Updated `pyproject.toml`:
  - Removed conditional dependency logic for `sys_platform` / `platform_machine`.
  - Removed `python-lzf` entirely.
  - Set requirement to `python-neo-lzf>=0.3.5`.

## Impact
- **Linux ARM64 users**: Will now use the `python-neo-lzf` wheels.
- **All other users**: No change in behavior, just a version bump.

## Versioning
This cleanup warrants a patch release (**v1.4.3**).